### PR TITLE
fix: updated the vpc version in complete example to resolve pre-commit alerts due to depracated vpc features

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -6,7 +6,6 @@ on:
     - opened
     - reopened
 
-
 jobs:
   auto-merge:
     uses: boldlink/terraform-module-support/.github/workflows/auto-merge.yaml@main

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -6,7 +6,6 @@ on:
     - opened
     - reopened
 
-permissions: write
 
 jobs:
   auto-merge:

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -6,6 +6,8 @@ on:
     - opened
     - reopened
 
+permissions: write
+
 jobs:
   auto-merge:
     uses: boldlink/terraform-module-support/.github/workflows/auto-merge.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: showcase routing with a static website hosted in an s3 bucket
 - feat: showcase in example alias usage with load balancer
 
+## [1.1.1] - 2023-08-14
+### Description
+- fix: updated vpc module version in complete example to use the latest version. This is because the previous version of the module had some deprecated features which caused pre-commit to fail.
 
 ## [1.1.0] - 2023-04-25
 ### Description
@@ -43,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial commit
 - feat: Route53 zone & records
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-route53/compare/1.0.2...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-route53/compare/1.0.1...HEAD
+[1.1.1]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.1.1
 [1.1.0]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.1.0
 [1.0.1]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.0.1
 [1.0.0]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ module "minimum_route53" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.64.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 4.64.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.12.0 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_r53_vpc"></a> [r53\_vpc](#module\_r53\_vpc) | boldlink/vpc/aws | 3.0.3 |
+| <a name="module_r53_vpc"></a> [r53\_vpc](#module\_r53\_vpc) | boldlink/vpc/aws | 3.0.4 |
 | <a name="module_route53"></a> [route53](#module\_route53) | ../../ | n/a |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,8 @@
 module "r53_vpc" {
+  #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
+  #checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   source                = "boldlink/vpc/aws"
-  version               = "3.0.3"
+  version               = "3.0.4"
   name                  = "${var.name}-vpc"
   cidr_block            = var.cidr_block
   enable_public_subnets = var.enable_public_subnets

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -1,4 +1,5 @@
 module "minimum_route53" {
+  #checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   source = "../../"
   name   = var.name
   tags   = var.tags


### PR DESCRIPTION
This PR was created to fix pre-commit alerts arising due to use of v3.0.4 of vpc which has deprecated features

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-route53/blob/fix/vpc-version-fix/CHANGELOG.md#111---2023-08-14)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
