### PR TITLE
fix: added CKV_AWS_338 to checkov file

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -6,3 +6,4 @@ external-modules-download-path: .external_modules
 framework: all
 skip-check:
 - CKV2_AWS_38 #"Ensure Domain Name System Security Extensions (DNSSEC) signing is enabled for Amazon Route 53 public hosted zones"
+- CKV_AWS_338 #Ensure CloudWatch log groups retains logs for at least 1 year

--- a/.github/workflows/module-examples-tests.yaml
+++ b/.github/workflows/module-examples-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: boldlink/terraform-module-support/.github/workflows/module-examples-tests.yaml@main
+    uses: boldlink/terraform-module-support/.github/workflows/module-examples-tests.yaml@fix/module-examples-tests
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/module-examples-tests.yaml
+++ b/.github/workflows/module-examples-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: boldlink/terraform-module-support/.github/workflows/module-examples-tests.yaml@fix/module-examples-tests
+    uses: boldlink/terraform-module-support/.github/workflows/module-examples-tests.yaml@main
     secrets:
       AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
       SLACK_WEBHOOK : ${{secrets.SLACK_WEBHOOK}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: showcase usage of `route53_record` policies in example, e.g `failover_routing_policy`
 - feat: showcase routing with a static website hosted in an s3 bucket
 - feat: showcase in example alias usage with load balancer
+- fix: CKV2_AWS_38 "Ensure Domain Name System Security Extensions (DNSSEC) signing is enabled for Amazon Route 53 public hosted zones"
+- fix: CKV_AWS_338 Ensure CloudWatch log groups retains logs for at least 1 year
+
+## [1.1.2] - 2023.-08-21
+- fix: added `CKV_AWS_338` to `.checkov.yaml` file
 
 ## [1.1.1] - 2023-08-14
 ### Description
@@ -46,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial commit
 - feat: Route53 zone & records
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-route53/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-route53/compare/1.1.2...HEAD
+
+[1.1.2]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.1.2
 [1.1.1]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.1.1
 [1.1.0]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.1.0
 [1.0.1]: https://github.com/boldlink/terraform-aws-route53/releases/tag/1.0.1

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ module "minimum_route53" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
-| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.12.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.13.1 |
+| <a name="provider_aws.us-east-1"></a> [aws.us-east-1](#provider\_aws.us-east-1) | 5.13.1 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,5 @@
 module "r53_vpc" {
   #checkov:skip=CKV_TF_1:Ensure Terraform module sources use a commit hash
-  #checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   source                = "boldlink/vpc/aws"
   version               = "3.0.4"
   name                  = "${var.name}-vpc"

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -1,5 +1,4 @@
 module "minimum_route53" {
-  #checkov:skip=CKV_AWS_338:Ensure CloudWatch log groups retains logs for at least 1 year
   source = "../../"
   name   = var.name
   tags   = var.tags


### PR DESCRIPTION
# Description

This PR adds CKV_AWS_338 to be skipped in checkov file

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-route53/blob/fix/CKV_AWS_338/CHANGELOG.md#112---2023-08-21)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [ ] Pre-commit (attach logs/print screen to this PR)
    * [ ] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
